### PR TITLE
feat: Add Open WebUI support and update README and app for service integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Easily monitor, manage, and experiment with these core open-source infrastructur
 - **PostgreSQL**: List/create databases and tables, insert/query data, run custom SQL.
 - **MongoDB**: List collections, insert/query documents.
 - **Hasura**: Hasura GraphQL engine to interact with PostgreSQL.
+- **Open WebUI**: Open-source web UI for local LLMs (Ollama backend required).
 - **Quick Links**: Access official documentation for each service.
 
 ---
@@ -52,6 +53,7 @@ This launches:
 - MongoDB
 - Hasura
 - The Streamlit dashboard
+- Open WebUI (for Ollama)
 
 ### 2️⃣ Install Python Dependencies (for local Streamlit development)
 
@@ -121,6 +123,8 @@ homelab/
 - [PostgreSQL Documentation](https://www.postgresql.org/docs/17/index.html)
 - [MongoDB Documentation](https://www.mongodb.com/docs/)
 - [Hasura Documentation](https://hasura.io/docs/latest/)
+- [Open WebUI Documentation](https://github.com/open-webui/open-webui)
+- [Ollama Documentation](https://ollama.com/docs)
 
 ---
 
@@ -145,3 +149,10 @@ MIT License
 
 - [justinrmiller](https://github.com/justinrmiller)
 - [claude](https://www.anthropic.com/claude)
+
+---
+
+## ℹ️ Notes
+
+- **Open WebUI** is included for managing and chatting with local LLMs, but **Ollama** (the backend LLM server) must be installed separately on your machine. You can download and install Ollama from [https://ollama.com/](https://ollama.com/).
+- All model downloads and management are handled via the Ollama CLI or web interface, not from this dashboard.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,19 @@ services:
       timeout: 10s
       retries: 3
 
+  # Open WebUI
+  openwebui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: openwebui
+    ports:
+      - "8082:8080"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
 volumes:
   valkey-data:
   kafka-data:


### PR DESCRIPTION
## ✨ Add Open WebUI Service to Homelab Dashboard

### Summary

- Added the Open WebUI service (ghcr.io/open-webui/open-webui:main) to docker-compose.yml with healthcheck and port mapping.
- Updated the Streamlit dashboard (`app.py`) to monitor and display Open WebUI status in the overview table and resources section.
- Updated the README to:
  - Document Open WebUI as part of the stack.
  - Clearly state that Ollama (the LLM backend) must be installed separately on the host machine.
  - Add links to Open WebUI and Ollama documentation.
  - Note that model management is handled via Ollama, not the dashboard.

### Notes

- Open WebUI provides a web interface for local LLMs, but requires Ollama to be running on the host.
- No model management is performed from the dashboard; all LLM models are managed via Ollama CLI or web UI.